### PR TITLE
Add latex_format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ doc/plantweb/*
 # Plantweb
 *.svg
 *.png
+*.eps

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -294,6 +294,7 @@ texinfo_documents = [
 def setup(app):
     app.add_stylesheet('styles/custom.css')
 
+
 # AutoAPI configuration
 autoapi_modules = {
     'plantweb': None

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -104,7 +104,7 @@ Complete options:
    user@host:~$ plantweb --help
    usage: plantweb [-h] [-v] [--version]
                    [--engine {auto,plantuml,graphviz,ditaa}]
-                   [--format {auto,svg,png}] [--server SERVER] [--no-cache]
+                   [--format {auto,svg,png,eps,epstext}] [--server SERVER] [--no-cache]
                    [--cache-dir CACHE_DIR]
                    sources [sources ...]
 
@@ -119,7 +119,7 @@ Complete options:
      --version             show program's version number and exit
      --engine {auto,plantuml,graphviz,ditaa}
                            engine to use to render diagram
-     --format {auto,svg,png}
+     --format {auto,svg,png,eps,epstext}
                            diagram export format
      --server SERVER       server to use for rendering
      --no-cache            do not use cache
@@ -204,6 +204,11 @@ absolute path from where the ``conf.py`` like this:
 
 The above will load the file from the Sphinx documentation root.
 
+.. versionadded:: 1.1.0
+
+The configuration in ``plantweb_defaults`` accepts a ``latex_format`` that sets
+the output file format used with the LaTeX builder. Default is ``eps`` which
+looks better than ``png``.
 
 Options
 +++++++
@@ -433,6 +438,7 @@ For example:
        "cache_dir": "~/.cache/plantweb",
        "engine": "plantuml",
        "format": "svg",
+       "latex_format": "eps",
        "use_cache": true
    }
 

--- a/lib/plantweb/args.py
+++ b/lib/plantweb/args.py
@@ -65,8 +65,8 @@ def validate_args(args):
     args.sources = sources
 
     # Check that format and engine compatibility
-    if args.format == 'svg' and args.engine == 'ditaa':
-        log.error('The ditaa engine doens\'t support the svg format')
+    if args.format != 'png' and args.engine == 'ditaa':
+        log.error('The ditaa engine only supports the png format')
         exit(1)
 
     # Prepare default datatypes

--- a/lib/plantweb/args.py
+++ b/lib/plantweb/args.py
@@ -118,7 +118,7 @@ def parse_args(argv=None):
         '--format',
         default='auto',
         help='diagram export format',
-        choices=['auto', 'svg', 'png']
+        choices=['auto', 'svg', 'png', 'eps', 'epstext']
     )
 
     parser.add_argument(

--- a/lib/plantweb/defaults.py
+++ b/lib/plantweb/defaults.py
@@ -39,6 +39,7 @@ log = logging.getLogger(__name__)
 DEFAULT_CONFIG = {
     'engine': 'plantuml',
     'format': 'svg',
+    'latex_format': 'eps',
     'server': 'http://plantuml.com/plantuml/',
     'use_cache': True,
     'cache_dir': '~/.cache/plantweb'

--- a/lib/plantweb/directive.py
+++ b/lib/plantweb/directive.py
@@ -137,7 +137,8 @@ class Plantweb(Image):
         try:
             # If building LaTex, use latex_output if set, otherwise
             # use None (uses value of 'output')
-            if builder.format == 'latex' and 'latex_format' in defaults.read_defaults():
+            if (builder.format == 'latex' and
+                    'latex_format' in defaults.read_defaults()):
                 frmt = defaults.read_defaults()['latex_format']
             else:
                 frmt = None

--- a/lib/plantweb/directive.py
+++ b/lib/plantweb/directive.py
@@ -135,9 +135,17 @@ class Plantweb(Image):
 
         # Execute plantweb call
         try:
+            # If building LaTex, use latex_output if set, otherwise
+            # use None (uses value of 'output')
+            if builder.format == 'latex' and 'latex_format' in defaults.read_defaults():
+                frmt = defaults.read_defaults()['latex_format']
+            else:
+                frmt = None
+
             output, frmt, engine, sha = render(
                 '\n'.join(content),
-                engine=self._get_engine_name()
+                engine=self._get_engine_name(),
+                format=frmt
             )
         except:
             msg = format_exc()
@@ -150,7 +158,7 @@ class Plantweb(Image):
             return [error]
 
         # Determine filename
-        filename = '{}.{}'.format(sha, frmt)
+        filename = '{}.{}'.format(sha, frmt[:3])
         imgpath = join(builder.outdir, builder.imagedir, 'plantweb')
 
         # Create images output folder

--- a/lib/plantweb/render.py
+++ b/lib/plantweb/render.py
@@ -79,7 +79,7 @@ def render_cached(
 
     :param str server: URL to PlantUML server.
     :param str format: File format to render the content. One of the supported
-     by the PlantUML server (``svg`` or ``png``).
+     by the PlantUML server (``svg``, ``png``, ``eps`` or ``epstext``).
     :param str content: Content to render with mandatory ``@startxxx`` tags.
     :param bool use_cache: Use local cache to avoid requesting the server for
      already rendered diagrams. If ``None``, the default value will be used.
@@ -142,9 +142,10 @@ def render(
      ``'plantuml'``, ``'graphviz'`` or ``'ditaa'``. If ``None``, the engine
      will be auto-determined by looking into the content for the ``@startxxxx``
      tags, and if unable to be auto-determined the default engine will be used.
-    :param str format: Format of the rendered content. Raster ``png`` or vector
-     ``svg``. Please note that engine ``ditaa`` can only render to ``png``. If
-     ``None``, the default formatwill always be selected unless the engine
+    :param str format: Format of the rendered content. Raster ``png``, vector
+     ``svg``, vector ``eps`` or vector with text ``epstext``.
+     Please note that engine ``ditaa`` can only render to ``png``. If
+     ``None``, the default format will always be selected unless the engine
      doesn't supports it.
     :param str server: URL to PlantUML server. This will passed as is to
      :func:`render_cached`. If ``None`` the default server URL will be used.

--- a/test/test_plantweb_directive.py
+++ b/test/test_plantweb_directive.py
@@ -41,7 +41,7 @@ def identify_content(content):
 def images_in(path):
     return [
         f for f in listdir(path)
-        if f.endswith('.png') or f.endswith('.svg')
+        if f.endswith('.png') or f.endswith('.svg') or f.endswith('.eps')
     ]
 
 

--- a/test/test_plantweb_main.py
+++ b/test/test_plantweb_main.py
@@ -53,7 +53,7 @@ def test_main(tmpdir, sources):
     out_names = [
         name
         for name, ext in [splitext(out) for out in listdir(getcwd())]
-        if ext in ['.png', '.svg']
+        if ext in ['.png', '.svg', '.eps']
     ]
 
     assert set(src_names) == set(out_names)


### PR DESCRIPTION
This PR adds a config option `latex_format` that is used for the Sphinx directive when the LaTeX builder is used. This fixes #4.
It is set to `eps` by default, since that looks better with LaTeX.

For non-LaTeX output (i.e. other builders and direct Python use), the behavior should remain unchanged.

I've added some text to the documentation in the "Sphinx Directive" section, but this could also be moved to the "Sphinx Setup" or "Overriding Defaults" section. I've guessed the `versionadded`, which might need updating.
