### PR TITLE
no verify the TLS cert on HTTPS calls

### DIFF
--- a/lib/plantweb/plantuml.py
+++ b/lib/plantweb/plantuml.py
@@ -120,7 +120,7 @@ def plantuml(server, extension, content):
     encoded = compress_and_encode(content)
     url = join(server, extension, encoded)
     log.debug('Calling URL:\n{}'.format(url))
-    response = get(url)
+    response = get(url, verify=False)
     response.raise_for_status()
     return response.content
 


### PR DESCRIPTION
This is an answer to #10 . It's regrettably simple but since this never called HTTPS endpoints before, verifying a non-TLS call should not impact anyone?

This will enable HTTPS calls -- it will throw a warning so it's slippery slope to creating tlsverify, tlscert, or tlskey args. Then the question is to add it to the CLI or not. I'm currently only interested in the Sphinx directives but I can see a world where the CLI might be handy too.