### PR TITLE
Fail on Syntax Error in HTTP header

### DIFF
--- a/lib/plantweb/plantuml.py
+++ b/lib/plantweb/plantuml.py
@@ -26,7 +26,7 @@ import logging
 from zlib import compress
 from posixpath import join
 
-from requests import get
+from requests import get, HTTPError
 from six.moves import range
 from six import indexbytes, unichr
 
@@ -122,6 +122,14 @@ def plantuml(server, extension, content):
     log.debug('Calling URL:\n{}'.format(url))
     response = get(url)
     response.raise_for_status()
+    if 'X-PlantUML-Diagram-Error' in response.headers:
+        raise HTTPError(
+            'PlantUML Diagram Error: {} at line: {}'.format(
+                response.headers['X-PlantUML-Diagram-Error'],
+                response.headers['X-PlantUML-Diagram-Error-Line']
+            ),
+            response=response
+        )
     return response.content
 
 

--- a/test/test_plantweb_render.py
+++ b/test/test_plantweb_render.py
@@ -27,6 +27,8 @@ from __future__ import print_function, division
 from os import listdir, getcwd
 from os.path import join, isfile
 
+from requests import HTTPError
+
 from plantweb import defaults
 from plantweb.render import render_file, render
 
@@ -54,6 +56,21 @@ def test_render(tmpdir, sources):
 
         # Assert cache exists
         assert isfile(join(cache_dir, '{}.{}'.format(sha, format)))
+
+
+def test_render_error():
+
+    src = """\
+@startuml
+Bob -> Alice : hello
+This is an intentional error
+@enduml
+    """
+
+    with raises(HTTPError, message="Expecting HTTP header with error") as e:
+        render(src, cacheopts={'use_cache': False})
+
+    assert 'PlantUML Diagram Error' in str(e.value)
 
 
 def test_render_forced_and_defaults(monkeypatch):


### PR DESCRIPTION
Plantweb server always returns 200 OK, even if the input contains a syntax error. Instead it uses HTTP headers to signal the error.
This PR adds a check for this header, fixes #12 