### PR TITLE
Directive URL

### DIFF
--- a/lib/plantweb/directive.py
+++ b/lib/plantweb/directive.py
@@ -172,6 +172,8 @@ class Plantweb(Image):
 
         # Determine relative path to image from source document directory
         filepath_relative = relpath(filepath, document_dir)
+        # Replace backslash with slash, otherwise they are removed:
+        filepath_relative = filepath_relative.replace('\\', '/')
         log.debug('Image relative path {}'.format(filepath_relative))
 
         # Run Image directive

--- a/lib/plantweb/directive.py
+++ b/lib/plantweb/directive.py
@@ -26,7 +26,7 @@ from logging import getLogger
 from traceback import format_exc
 from distutils.dir_util import mkpath
 from abc import ABCMeta, abstractmethod
-from os.path import join, relpath, dirname, isfile, isabs
+from os.path import join, relpath, dirname, isfile, isabs, realpath
 
 from six import add_metaclass
 from docutils import nodes
@@ -106,6 +106,7 @@ class Plantweb(Image):
 
         # Determine document directory
         document_dir = dirname(env.doc2path(env.docname))
+        document_dir = realpath(document_dir)
 
         # Load content to render
         if not self.arguments:


### PR DESCRIPTION
The sphinx directive fails on Windows because the backslashes in the url are removed in the Image directive. I have added a simple hack to replace backslashes with slashes, I am not sure if this is the right way to do it, but it works!