### PR TITLE
Fix flake pre-commit hook command in docs

### DIFF
--- a/doc/developer.rst
+++ b/doc/developer.rst
@@ -21,7 +21,7 @@ Setup Development Environment
    .. code-block:: sh
 
       sudo pip3 install flake8 pep8-naming
-      flake8 --install-hook
+      flake8 --install-hook git
       git config flake8.strict true
 
 


### PR DESCRIPTION
To add the `flake8` git hook, the command [requires the VCS-name as argument](https://flake8.pycqa.org/en/latest/user/using-hooks.html#built-in-hook-integration) (at least, that's the case in newer versions).