### PR TITLE
fix: duplicated images in build dir

### DIFF
--- a/lib/plantweb/directive.py
+++ b/lib/plantweb/directive.py
@@ -151,7 +151,7 @@ class Plantweb(Image):
 
         # Determine filename
         filename = '{}.{}'.format(sha, frmt)
-        imgpath = join(builder.outdir, builder.imagedir, 'plantweb')
+        imgpath = join(builder.outdir, builder.imagedir)
 
         # Create images output folder
         log.debug('imgpath set to {}'.format(imgpath))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21083014/76738499-b7415b80-67a5-11ea-87cb-16db0a0d8c10.png)
Current master branch will create unnessary file in build dir.

test fail at py27 `..\..\..\test\test_plantweb_directive.py:111:` even without any change 
```
SphinxWarning: while setting up extension sphinx.domains.changeset: directive 'deprecated' is already registered, it will be overridde
```