### PR TITLE
Removed dependency on distutils

### DIFF
--- a/lib/plantweb/args.py
+++ b/lib/plantweb/args.py
@@ -23,7 +23,7 @@ from __future__ import unicode_literals, absolute_import
 from __future__ import print_function, division
 
 import logging
-from distutils.dir_util import mkpath
+from os import makedirs
 from os.path import isfile, abspath, expanduser
 
 from . import __version__
@@ -87,7 +87,7 @@ def validate_args(args):
 
     # Ensure cache dir
     if not args.no_cache:
-        mkpath(expanduser(args.cache_dir))
+        makedirs(expanduser(args.cache_dir), exist_ok=True)
 
     return args
 

--- a/lib/plantweb/defaults.py
+++ b/lib/plantweb/defaults.py
@@ -31,7 +31,7 @@ from traceback import format_exc
 from sys import getdefaultencoding
 from subprocess import Popen, PIPE
 from importlib import import_module
-from distutils.spawn import find_executable
+from shutil import which
 from os.path import isfile, expanduser, join
 
 
@@ -95,7 +95,7 @@ def _read_defaults_git(path):
     See :data:`DEFAULTS_PROVIDERS` for inner workings.
     """
     # Find git executable
-    git = find_executable('git')
+    git = which('git')
     if not git:
         log.debug(
             'Unable to read defaults from repository. '

--- a/lib/plantweb/directive.py
+++ b/lib/plantweb/directive.py
@@ -24,7 +24,7 @@ from __future__ import print_function, division
 
 from logging import getLogger
 from traceback import format_exc
-from distutils.dir_util import mkpath
+from os import makedirs
 from abc import ABCMeta, abstractmethod
 from os.path import join, relpath, dirname, isfile, isabs, realpath
 
@@ -155,7 +155,7 @@ class Plantweb(Image):
 
         # Create images output folder
         log.debug('imgpath set to {}'.format(imgpath))
-        mkpath(imgpath)
+        makedirs(imgpath, exist_ok=True)
 
         # Write content
         filepath = join(imgpath, filename)

--- a/lib/plantweb/render.py
+++ b/lib/plantweb/render.py
@@ -24,7 +24,7 @@ from __future__ import print_function, division
 
 import logging
 from hashlib import sha256
-from distutils.dir_util import mkpath
+from os import makedirs
 from os.path import basename, splitext, isfile, expanduser, join
 
 from .plantuml import plantuml
@@ -116,7 +116,7 @@ def render_cached(
             return (fd.read(), sha)
 
     # No cache, make sure the directory is available
-    mkpath(cache_dir)
+    makedirs(cache_dir, exist_ok=True)
 
     # Normal render and save cache
     output = plantuml(server, format, content)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,7 +28,7 @@ from os import listdir
 from shutil import rmtree
 from tempfile import mkdtemp
 from logging import getLogger, NOTSET
-from distutils.dir_util import mkpath
+from os import makedirs
 from os.path import join, abspath, dirname, normpath
 
 from pytest import fixture
@@ -66,7 +66,7 @@ class SphinxTest(object):
         self.outdir = join(self.workspace, '_build')
         self.doctreedir = join(self.workspace, '_doctrees')
 
-        mkpath(self.srcdir)
+        makedirs(self.srcdir, exist_ok=True)
 
         # Specify plantweb overrides
         self.cachedir = join(self.workspace, '_cache')

--- a/test/sphinxconf/conf.py
+++ b/test/sphinxconf/conf.py
@@ -65,7 +65,7 @@ release = '1.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/test/test_plantweb_defaults.py
+++ b/test/test_plantweb_defaults.py
@@ -30,7 +30,7 @@ from os import chdir, getcwd
 from os.path import abspath, join
 from subprocess import check_call
 from shlex import split as shsplit
-from distutils.spawn import find_executable
+from shutil import which
 
 from pytest import mark
 
@@ -38,7 +38,7 @@ from plantweb import defaults
 
 
 @mark.skipif(
-    find_executable('git') is None,
+    which('git') is None,
     reason='git executable is missing'
 )
 def test_defaults(tmpdir, monkeypatch):


### PR DESCRIPTION
These changes removed the dependencies on the distutils packages as it will be removed in Python 3.12. 

I've replaced: distutils.spawn.find_executable by shutil.which and distutils.dir_util.mkpath by os.makedirs

It addresses issue #25